### PR TITLE
fix: correct download progress calculation bug in docker UI

### DIFF
--- a/docker/app/download_manager.py
+++ b/docker/app/download_manager.py
@@ -181,9 +181,8 @@ class DownloadManager:
                     job.current_file = msg
 
                 def on_progress(frac, speed, idx, total, _bytes):
-                    base = done_eps / total_eps if total_eps else 0
-                    chunk = (1 / total_eps) if total_eps else 0
-                    job.progress = min(base + chunk * frac, 1.0)
+                    completed = done_eps + (idx - 1) + frac
+                    job.progress = min(completed / total_eps, 1.0) if total_eps else 0.0
                     job.speed = speed
                     job.current_idx = done_eps + idx
                     job.total_files = total_eps


### PR DESCRIPTION
The progress calculation previously divided the current file's fractional progress by the total number of files without accounting for already completed files. This resulted in the UI repeatedly showing 0% to ~1% for every file downloaded in a batch. This updates the math to add the number of completed files to the fractional progress, allowing the progress bar to correctly scale to 100%.